### PR TITLE
Fix missing namespace for Extension

### DIFF
--- a/src/Extensions/AdminPaginator.php
+++ b/src/Extensions/AdminPaginator.php
@@ -2,6 +2,7 @@
 
 namespace Goldfinch\Helpers\Extensions;
 
+use SilverStripe\Core\Extension;
 use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\Forms\GridField\GridFieldPageCount;
 use Symbiote\GridFieldExtensions\GridFieldConfigurablePaginator;


### PR DESCRIPTION
The recent change for 2.0.17 causes a fatal error due to removal of a namespace in AdminPaginator.php

This PR puts the namespace back in.